### PR TITLE
Removed AZ consistency check on ECS create

### DIFF
--- a/otc
+++ b/otc
@@ -1403,10 +1403,6 @@ ECSCreate() {
 			exit 2
 		fi
 	fi
-	if test -n "$SUBNETAZ" -a "$SUBNETAZ" != "$AZ"; then
-		echo "ERROR: AZ ($AZ) must match subnets AZ ($SUBNETAZ)" 1>&2
-		exit 2
-	fi
 
 	OPTIONAL=""
 	if [ "$CREATE_ECS_WITH_PUBLIC_IP" == "true" ]; then


### PR DESCRIPTION
AZ defined for subnet not seems to be relevant while creating ECS.
As ECS can be spawned in either za1 or az2, there should be no such check.