### PR TITLE
Tcp non roundrobin must not be sticky

### DIFF
--- a/otc
+++ b/otc
@@ -1474,6 +1474,7 @@ createListener() {
 	if test -z "$BEPROTO"; then BEPROTO="$3"; fi
 	if test -z "$BEPORT"; then BEPORT=$4; fi
 	if test "$3" = "HTTP" -o "$3" = "HTTPS"; then STICKY="\"session_sticky\": \"true\", "; fi
+	if test "$3" = "HTTP" -o "$3" = "HTTPS" -o "$3" = "TCP" && test "$ALG" != "roundrobin"; then STICKY="\"session_sticky\": \"false\", "; fi
 	curlpostauth $TOKEN "{ \"name\": \"$2\", \"loadbalancer_id\": \"$1\", \"protocol\": \"$3\", \"port\": $4, \"backend_protocol\": \"$BEPROTO\", \"backend_port\": $BEPORT, $STICKY\"lb_algorithm\": \"$ALG\" }" "$AUTH_URL_ELB/listeners" | jq '.[]'
 
 }

--- a/otc
+++ b/otc
@@ -1474,7 +1474,7 @@ createListener() {
 	if test -z "$BEPROTO"; then BEPROTO="$3"; fi
 	if test -z "$BEPORT"; then BEPORT=$4; fi
 	if test "$3" = "HTTP" -o "$3" = "HTTPS"; then STICKY="\"session_sticky\": \"true\", "; fi
-	curlpostauth $TOKEN "{ \"name\": \"$3\", \"loadbalancer_id\": \"$1\", \"protocol\": \"$3\", \"port\": $4, \"backend_protocol\": \"$BEPROTO\", \"backend_port\": $BEPORT, $STICKY\"lb_algorithm\": \"$ALG\" }" "$AUTH_URL_ELB/listeners" | jq '.[]'
+	curlpostauth $TOKEN "{ \"name\": \"$2\", \"loadbalancer_id\": \"$1\", \"protocol\": \"$3\", \"port\": $4, \"backend_protocol\": \"$BEPROTO\", \"backend_port\": $BEPORT, $STICKY\"lb_algorithm\": \"$ALG\" }" "$AUTH_URL_ELB/listeners" | jq '.[]'
 
 }
 


### PR DESCRIPTION
    https://docs.otc.t-systems.com/en-us/doc/pdf/20161228/20161228193247_37203.pdf
     If the value of protocol is HTTP, HTTPS, or TCP, and the value of
     lb_algorithm is not roundrobin, the value of this parameter can only be
     false.
